### PR TITLE
Allow for async callback in rpc response handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -372,13 +372,16 @@ function rpcCall(bugout, pk, call, args, nonce, callback) {
   if (bugout.api[call]) {
     bugout.api[call](bugout.address(pk), args, function(result) {
       packet["rr"] = JSON.stringify(result);
+      packet = makePacket(bugout, packet);
+      packet = encryptPacket(bugout, pk, packet);
+      sendRaw(bugout, packet);
     });
   } else {
     packet["rr"] = JSON.stringify({"error": "No such API call."});
+    packet = makePacket(bugout, packet);
+    packet = encryptPacket(bugout, pk, packet);
+    sendRaw(bugout, packet);
   }
-  packet = makePacket(bugout, packet);
-  packet = encryptPacket(bugout, pk, packet);
-  sendRaw(bugout, packet);
 }
 
 function sawPeer(bugout, pk, ek, identifier) {

--- a/test.js
+++ b/test.js
@@ -323,3 +323,26 @@ test("heartbeat seen and timeout", function(t) {
   });
 });
 
+test("RPC response handles async callback", function(t) {
+  t.plan(1);
+
+  var bs = new Bugout({wt: wtest});
+  var bc = new Bugout(bs.address(), {wt: wtest2});
+
+  bs.register("ping", function(address, args, cb) {
+    args["pong"] = true;
+    setTimeout(function() {
+      cb(args);
+    }, 1000);
+  });
+
+  bc.on("server", function(address) {
+    bc.rpc("ping", {}, function(response) {
+      t.ok(response.pong, "RPC server response check async pong");
+    });
+  });
+
+  bs.torrent.on("infoHash", function() {
+    bs.torrent.addPeer("127.0.0.1:" + bc.wt.address().port);
+  });
+});


### PR DESCRIPTION
Currently, when a response is being handled, the callback must
be called before the before response function returns. This is
because the response returns immidiately, and doesn't wait for
the callback to be called.

To allow for async response handling, this simply waits for the
callback to be called before returning.

Just some quick proof that the test case fails as specified in https://github.com/chr15m/bugout/issues/25

![image](https://user-images.githubusercontent.com/1775468/83990055-59409200-a916-11ea-924a-581641b069b3.png)

NW