### PR TITLE
Opts.torrent

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -18,6 +18,7 @@ The following can be passed as the second `opts` argument to `Bugout(identifier,
 
  * `wt` - a [WebTorrent instance](https://webtorrent.io/docs) to re-use. Pass this in if you're making connections to multiple Bugout channels.
  * `wtOpts` - options that will be passed when [creating the WebTorrent object](https://github.com/webtorrent/webtorrent/blob/master/docs/api.md#client--new-webtorrentopts).
+ * `torrent` - a torrent to extend with Bugout RPC / gossip extension. If provided a new torrent will not be created.
  * `torrentOpts` - options that will be passed to the [WebTorrent seed method](https://github.com/webtorrent/webtorrent/blob/master/docs/api.md#clientseedinput-opts-function-onseed-torrent-).
  * `seed` - base58 encoded seed used to generate an [nacl signing key pair](https://github.com/dchest/tweetnacl-js#signatures).
  * `keyPair` - pass [nacl signing key pair](https://github.com/dchest/tweetnacl-js#signatures) directly rather than a seed.

--- a/index.js
+++ b/index.js
@@ -86,6 +86,10 @@ function Bugout(identifier, opts) {
     } else {
       this.torrent.on('ready', this._onTorrent.bind(this));
     }
+    // Could be existing wires...
+    this.torrent.wires.forEach((wire) => {
+      attach(this, this.identifier, wire, wire.addr);
+    });
   } else {
     this.wt = this.wt || new WebTorrent(Object.assign({tracker: trackeropts}, opts["wtOpts"] || {}));
     this.torrent = this.wt.seed(blob, Object.assign({"name": this.identifier, "announce": this.announce}, opts["torrentOpts"] || {}), partial(function(bugout, torrent) {

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function Bugout(identifier, opts) {
     if (this.torrent.ready) {
       this._onTorrent();
     } else {
-      this.torrent.on('ready', partial(this._onTorrent.bind(this)));
+      this.torrent.on('ready', this._onTorrent.bind(this));
     }
   } else {
     this.wt = this.wt || new WebTorrent(Object.assign({tracker: trackeropts}, opts["wtOpts"] || {}));

--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ test.onFinish(function() {
 });
 
 test('Instantiation', function (t) {
-  t.plan(10);
+  t.plan(12);
 
   var b1 = new Bugout({seed: "BohNtZ24TrgMwZTLx9VDKtcZARNVuCt5tnecAAxYtTBC8pC61uGN", wt: wtest});
   t.equal(b1.identifier, "bYSkTy24xXJj6dWe79ZAQXKJZrn2n983SQ", "server identifier");
@@ -49,6 +49,11 @@ test('Instantiation', function (t) {
     console.log(b4.torrent.infoHash);
     t.equal(b4.torrent.infoHash, "5486696a87e91c6c7fcfc6279c9b08709c7aa61f", "client infoHash");
   });
+
+  var b5 = new Bugout({torrent: b4.torrent});
+  t.equal(b5.torrentCreated, false);
+  b5.destroy();
+  t.equal(b4.torrent, b5.torrent);
 });
 
 test("Connectivity events", function(t) {


### PR DESCRIPTION
This change allows a caller to utilize an existing `Torrent` instance. For my project, this is desirable because I am using the torrent to distribute the content of a web application, and using bugout to allow the application to communicate between client / server.

Basically, I allow the caller to seed or add a torrent, then instantiate `Bugout` on top of the torrent. I also modified the `destroy` method to leave the torrent intact if it was provided by the caller. I added a test to ensure the provided torrent is used. I updated the documentation to mention the new option.

Here is an example of how I am using this functionality:

First, on the server-side, I seed the torrent:
https://github.com/btimby/ug/blob/master/src/engine/server.js#L312

Then instantiate Bugout, this is done in the `seed()` callback, which is fairly late, but it works:
https://github.com/btimby/ug/blob/master/src/engine/server.js#L99

On the client-side, I `add()` the torrent, then instantiate `Bugout`, allowing it to wire up the protocol extension before fetching the torrent contents.
https://github.com/btimby/ug/blob/master/src/engine/server.js#L331

Please let me know if I missed anything or made any mistakes.