### PR TITLE
Fix messageboard example iOS PWA support

### DIFF
--- a/docs/examples/messageboard.html
+++ b/docs/examples/messageboard.html
@@ -5,6 +5,7 @@
   <meta content="width=device-width, initial-scale=1" name="viewport">
   <meta content="yes" name="mobile-web-app-capable">
   <meta content="black" name="apple-mobile-web-app-status-bar-style">
+  <meta content="yes" name="apple-mobile-web-app-capable">
   <title>Bugout messageboard example</title>
   <script src="../bugout.min.js" type="application/javascript"></script>
 </head>


### PR DESCRIPTION
`<meta name="apple-mobile-web-app-capable">` is for iOS. `<meta name="mobile-web-app-capable">` is for Android.