### PR TITLE
catch lib crash when call rpc without args closes #63

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,9 +335,13 @@ function onMessage(bugout, identifier, wire, message) {
         } else if (packet.y == "r") { // rpc call
           debug("rpc", identifier, packet);
           var call = packet.c.toString();
-          var argsstring = packet.a.toString();
           try {
-            var args = JSON.parse(argsstring);
+            if (typeof packet.a !== 'undefined' && packet.a !== null) {
+              var argsstring = packet.a.toString();
+              var args = JSON.parse(argsstring);
+            } else {
+              var args = null
+            }
           } catch(e) {
             var args = null;
             debug("Malformed args JSON: " + argsstring);

--- a/index.js
+++ b/index.js
@@ -336,12 +336,8 @@ function onMessage(bugout, identifier, wire, message) {
           debug("rpc", identifier, packet);
           var call = packet.c.toString();
           try {
-            if (typeof packet.a !== 'undefined' && packet.a !== null) {
-              var argsstring = packet.a.toString();
-              var args = JSON.parse(argsstring);
-            } else {
-              var args = null
-            }
+            var argsstring = packet["a"] ? packet.a.toString() : "null";
+            var args = JSON.parse(argsstring);
           } catch(e) {
             var args = null;
             debug("Malformed args JSON: " + argsstring);

--- a/index.js
+++ b/index.js
@@ -335,8 +335,8 @@ function onMessage(bugout, identifier, wire, message) {
         } else if (packet.y == "r") { // rpc call
           debug("rpc", identifier, packet);
           var call = packet.c.toString();
+          var argsstring = packet["a"] ? packet.a.toString() : "null";
           try {
-            var argsstring = packet["a"] ? packet.a.toString() : "null";
             var args = JSON.parse(argsstring);
           } catch(e) {
             var args = null;

--- a/test.js
+++ b/test.js
@@ -150,8 +150,7 @@ test("RPC Call without passing any message/data", function(t) {
   const bc = new Bugout(bs.address(), {dht: false, tracker: false});
 
   bs.register("call_without_args", function(pk,args){
-    console.dir(args)
-    t.assert(args === null , 'args should be null , when called without args from another peer')
+    t.assert(args === null, 'args should be null, when called without args from another peer')
   });
   bs.register("call_with_args", function(pk,args){
     t.assert(typeof args === 'object' , 'type of args should be an object')


### PR DESCRIPTION
closes #63

Prefered args to left null  (as it is in catch block)  instead of an empty object  , because that  leads to  another crashing in another line ( if a recall corectly , in a JSON.parse  line )