### PR TITLE
apply checks before use torrent discovery tracker

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,12 +109,12 @@ Bugout.prototype.WebTorrent = WebTorrent;
 Bugout.prototype._onTorrent = function() {
   debug("torrent", this.identifier, this.torrent);
   this.emit("torrent", this.identifier, this.torrent);
-  if (this.torrent.discovery.tracker) {
+  if (this?.torrent?.discovery?.tracker) {
     this.torrent.discovery.tracker.on("update", partial(function(bugout, update) {
       bugout.emit("tracker", bugout.identifier, update);
     }, this));
   }
-  this.torrent.discovery.on("trackerAnnounce", partial(function(bugout) {
+  this?.torrent?.discovery?.on("trackerAnnounce", partial(function(bugout) {
     bugout.emit("announce", bugout.identifier);
     bugout.connections();
   }, this));


### PR DESCRIPTION
I have tested , seems didnt appeared again the issue. closes #70

Any chance to sync npm with the current head after merging ? 
seems latest sync was on this commit : 00b0c2d